### PR TITLE
Use namespace import for nanoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ array(50, () => name())
 ### Direct access to more performant/popular packages
 
 ```ts
-import { nanoid, uuid, password } from 'minifaker'
+import { nanoId, uuid, password } from 'minifaker'
 
-nanoid.nanoid()
+nanoId.nanoid()
 uuid.v4()
 password.generate()
 ```
@@ -89,7 +89,7 @@ random.arrayElement|n/a|arrayElement
 random.number,random.float|n/a|number
 random.boolean|n/a|boolean
 random.uuid|n/a|uuid -> `uuid` funcs
-n/a|n/a|nanoid -> `nanoid` funcs
+n/a|n/a|nanoid -> `nanoId` funcs
 name.firstName|en,fr|firstName
 phone.phoneNumber|en,fr,fr-CA|phoneNumber
 address.cityName|en,fr|cityName

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Packages
 import _seedrandom from 'seedrandom' // seedrandom().quick() is 1.8x faster than native Math.random() + I can set a seed :)
-import _nanoid from 'nanoid'
+import * as _nanoid from 'nanoid'
 import * as _uuid from 'uuid'
 import _generatePassword from 'generate-password'
 


### PR DESCRIPTION
This fixes the import of `nanoid`, which as of version 3.0 uses named exports (https://github.com/ai/nanoid/releases/tag/3.0.0).  I discovered this problem when adding minifaker to my vite project, which uses ESM and fails on this default import of nanoid.

I also fixed the capitalization of `nanoId` in the readme, which is how the namespace is actually exported.