### PR TITLE
Generate types for all exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "build": "ts-node bundle.ts && tsc ./src/index.ts --declaration --emitDeclarationOnly --downlevelIteration --esModuleInterop --outdir ./dist/types",
+    "build": "ts-node bundle.ts && tsc --project ./tsconfig.esmtypes.json && tsc --project ./tsconfig.cjstypes.json && tsc --project ./tsconfig.types.json",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/tsconfig.cjstypes.json
+++ b/tsconfig.cjstypes.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.types.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs"
+  }
+}

--- a/tsconfig.esmtypes.json
+++ b/tsconfig.esmtypes.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.types.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm"
+  }
+}

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
+  "include": ["./src/index.ts"]
+}


### PR DESCRIPTION
Ran into the problem that typescript 5 no longer correctly resolves minifaker types.
I'll be honest and say that I'm not certain if this is the correct way of solving that (I've never build a lib that combines cjs and esm), but it does seem to work.

Fixes #14 